### PR TITLE
It is now possible to run only bin/manage_tuntap script via sudo, not /bi

### DIFF
--- a/bin/manage_tuntap
+++ b/bin/manage_tuntap
@@ -22,22 +22,22 @@
 # a virtual machine to the Internet.
 # It is not intended for standalone usage.
 
-: ${NETKIT_HOME:=$VLAB_HOME}
-
-# Script arguments follow (arguments from 2 to 5 are only required when action
+# Script arguments follow (arguments from 3 to 6 are only required when action
 # is "start").
-ACTION=$1         # either "start" or "stop"
-USER_NAME=$2      # name of the user the tunnel is being configured for
-TAP_ADDRESS=$3    # address of the (host side) tap interface
-GUEST_ADDRESS=$4  # address of the (virtual machine side) guest interface 
-HUB_NAME=$5       # name of the virtual hub
+NETKIT_HOME=$1    # NETKIT_HOME environment variable. Environment was reset after sudo so we pass it in command line.
+ACTION=$2         # either "start" or "stop"
+USER_NAME=$3      # name of the user the tunnel is being configured for
+TAP_ADDRESS=$4    # address of the (host side) tap interface
+GUEST_ADDRESS=$5  # address of the (virtual machine side) guest interface
+HUB_NAME=$6       # name of the virtual hub
 
 
 TAP_DEVICE="nk_tap_$USER_NAME"
 
 
-# Include some important entries inside the path
-export PATH=$PATH:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
+# Include some important entries inside the path along with $NETKIT_HOME/bin
+PATH=$PATH:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin:$NETKIT_HOME/bin
+export PATH
 
 # Use the correct syntax for echo, depending on the shell being used
 if type source > /dev/null 2>&1; then

--- a/bin/script_utils
+++ b/bin/script_utils
@@ -269,27 +269,23 @@ startInetHub() {
    if [ ! -S "$1" ] || ! someOneUses "$1"; then
       # Either socket does not exist yet or it is still unused
       if [ "$USE_SUDO" = "yes" ]; then
-         # Default sudo configuration resets environment variables for security
-         # reasons (depends on the configuration in sudoers, and may happen even
-         # when using -E)
-         PRESERVE_ENV=$(env | egrep "(^NETKIT)|(^PATH=)")
-         TUNTAP_COMMAND="sudo -p \"$USER's password:\" /bin/sh -c \"eval $PRESERVE_ENV; $NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1\""
+         TUNTAP_COMMAND="sudo -p \"$USER's password:\" $NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1"
       else
-         TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1\""
+         TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1\""
       fi
       if [ -z "$BE_QUIET" ]; then
          echo "******** Starting Internet connected virtual hub ********"
          echo "   $TAP_ADDRESS (host side) - $GUEST_ADDRESS (guest side)"
          echo "********     (root privileges are required)      ********"
          run_command "$JUST_PRINT" \
-                     "$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1" \
+                     "$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1" \
                      "$TUNTAP_COMMAND" || \
             { echo 1>&2 "Error while configuring the tunnel."; exit 1; }
          echo "************** Abandoning root privileges ***************"
          echo
       else
          run_command "$JUST_PRINT" \
-                     "$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1" \
+                     "$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1" \
                      "$TUNTAP_COMMAND" >/dev/null || \
             { echo 1>&2 "Error while configuring the tunnel."; exit 1; }
       fi

--- a/bin/vclean
+++ b/bin/vclean
@@ -318,14 +318,10 @@ if [ ! -z "$REMOVE_TUNNELS" ]; then
       echo "   This will affect tap configurations for $USER_STRING."
       echo "******** This operation requires root privileges ********"
    fi
-   if [ "$USE_SUDO" = "yes" ]; then
-      # Default sudo configuration resets environment variables for security
-      # reasons (depends on the configuration in sudoers, and may happen even
-      # when using -E)
-      PRESERVE_ENV=$(env | egrep "(^NETKIT)|(^PATH=)")
-      TUNTAP_COMMAND="sudo -p \"$USER's password:\" /bin/sh -c \"eval $PRESERVE_ENV; $NETKIT_HOME/bin/manage_tuntap stop\""
+   if [ "$USE_SUDO" = "yes" ]; then      
+      TUNTAP_COMMAND="sudo -p \"$USER's password:\" $NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME stop\""
    else
-      TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap stop\""
+      TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME stop\""
    fi
    if [ -z "$BE_QUIET" ]; then   
       run_command "" \


### PR DESCRIPTION
It is now possible to run only bin/manage_tuntap script via sudo, not /bin/sh.
This is very important if netkit is used on public computers. Starting /bin/sh via sudo is rather bad idea.

Now your /etc/sudoers could contain just a line like this:
student ALL=NOPASSWD: /usr/local/netkit/bin/manage_tuntap

This commit fixes the https://github.com/maxonthegit/netkit-core/issues/17 issue.
