### PR TITLE
It should be a way to show unicast and brodcast on link layer

### DIFF
--- a/bin/manage_tuntap
+++ b/bin/manage_tuntap
@@ -22,22 +22,22 @@
 # a virtual machine to the Internet.
 # It is not intended for standalone usage.
 
-: ${NETKIT_HOME:=$VLAB_HOME}
-
-# Script arguments follow (arguments from 2 to 5 are only required when action
+# Script arguments follow (arguments from 3 to 6 are only required when action
 # is "start").
-ACTION=$1         # either "start" or "stop"
-USER_NAME=$2      # name of the user the tunnel is being configured for
-TAP_ADDRESS=$3    # address of the (host side) tap interface
-GUEST_ADDRESS=$4  # address of the (virtual machine side) guest interface 
-HUB_NAME=$5       # name of the virtual hub
+NETKIT_HOME=$1    # NETKIT_HOME environment variable. Environment was reset after sudo so we pass it in command line.
+ACTION=$2         # either "start" or "stop"
+USER_NAME=$3      # name of the user the tunnel is being configured for
+TAP_ADDRESS=$4    # address of the (host side) tap interface
+GUEST_ADDRESS=$5  # address of the (virtual machine side) guest interface
+HUB_NAME=$6       # name of the virtual hub
 
 
 TAP_DEVICE="nk_tap_$USER_NAME"
 
 
-# Include some important entries inside the path
-export PATH=$PATH:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin
+# Include some important entries inside the path along with $NETKIT_HOME/bin
+PATH=$PATH:/bin:/usr/bin:/usr/local/bin:/sbin:/usr/sbin:/usr/local/sbin:$NETKIT_HOME/bin
+export PATH
 
 # Use the correct syntax for echo, depending on the shell being used
 if type source > /dev/null 2>&1; then

--- a/bin/script_utils
+++ b/bin/script_utils
@@ -269,27 +269,23 @@ startInetHub() {
    if [ ! -S "$1" ] || ! someOneUses "$1"; then
       # Either socket does not exist yet or it is still unused
       if [ "$USE_SUDO" = "yes" ]; then
-         # Default sudo configuration resets environment variables for security
-         # reasons (depends on the configuration in sudoers, and may happen even
-         # when using -E)
-         PRESERVE_ENV=$(env | egrep "(^NETKIT)|(^PATH=)")
-         TUNTAP_COMMAND="sudo -p \"$USER's password:\" /bin/sh -c \"eval $PRESERVE_ENV; $NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1\""
+         TUNTAP_COMMAND="sudo -p \"$USER's password:\" $NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1"
       else
-         TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1\""
+         TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1\""
       fi
       if [ -z "$BE_QUIET" ]; then
          echo "******** Starting Internet connected virtual hub ********"
          echo "   $TAP_ADDRESS (host side) - $GUEST_ADDRESS (guest side)"
          echo "********     (root privileges are required)      ********"
          run_command "$JUST_PRINT" \
-                     "$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1" \
+                     "$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1" \
                      "$TUNTAP_COMMAND" || \
             { echo 1>&2 "Error while configuring the tunnel."; exit 1; }
          echo "************** Abandoning root privileges ***************"
          echo
       else
          run_command "$JUST_PRINT" \
-                     "$NETKIT_HOME/bin/manage_tuntap start $USER $2 $3 $1" \
+                     "$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME start $USER $2 $3 $1" \
                      "$TUNTAP_COMMAND" >/dev/null || \
             { echo 1>&2 "Error while configuring the tunnel."; exit 1; }
       fi

--- a/bin/script_utils
+++ b/bin/script_utils
@@ -263,7 +263,7 @@ someOneUses() {
 startInetHub() {
    local HUB_COMMAND COMPLETE_COMMAND TAP_DEVICE TUNTAP_COMMAND PRESERVE_ENV
    TAP_DEVICE="nk_tap_$USER"
-   HUB_COMMAND="$NETKIT_HOME/bin/uml_switch -tap $TAP_DEVICE -hub -unix $1 </dev/null 2>&1"
+   HUB_COMMAND="$NETKIT_HOME/bin/uml_switch -tap $TAP_DEVICE -unix $1 </dev/null 2>&1"
    COMPLETE_COMMAND="${HUB_COMMAND} | awk -v SWITCHNAME=$1 -v USER=$USERID -v CURRENTDATE=\"`date +\"%Y/%m/%d %H:%M:%S\"`\" \
                '{printf \"%s %15s %25s %s\n\", CURRENTDATE, USER, SWITCHNAME, \$0}' > ${HUB_LOG} &"
    if [ ! -S "$1" ] || ! someOneUses "$1"; then
@@ -302,7 +302,7 @@ startInetHub() {
 # This function starts a hub, if it does not exist yet
 startHub() {
    local HUB_COMMAND COMPLETE_COMMAND
-   HUB_COMMAND="$NETKIT_HOME/bin/uml_switch -hub -unix $1 </dev/null 2>&1"
+   HUB_COMMAND="$NETKIT_HOME/bin/uml_switch -unix $1 </dev/null 2>&1"
    COMPLETE_COMMAND="${HUB_COMMAND} | awk -v SWITCHNAME=$1 -v USER=$USERID -v CURRENTDATE=\"`date +\"%Y/%m/%d %H:%M:%S\"`\" \
                 '{printf \"%s %15s %25s %s\n\", CURRENTDATE, USER, SWITCHNAME, \$0}' > ${HUB_LOG} &"
    if [ ! -S "$1" ]; then

--- a/bin/vclean
+++ b/bin/vclean
@@ -318,14 +318,10 @@ if [ ! -z "$REMOVE_TUNNELS" ]; then
       echo "   This will affect tap configurations for $USER_STRING."
       echo "******** This operation requires root privileges ********"
    fi
-   if [ "$USE_SUDO" = "yes" ]; then
-      # Default sudo configuration resets environment variables for security
-      # reasons (depends on the configuration in sudoers, and may happen even
-      # when using -E)
-      PRESERVE_ENV=$(env | egrep "(^NETKIT)|(^PATH=)")
-      TUNTAP_COMMAND="sudo -p \"$USER's password:\" /bin/sh -c \"eval $PRESERVE_ENV; $NETKIT_HOME/bin/manage_tuntap stop\""
+   if [ "$USE_SUDO" = "yes" ]; then      
+      TUNTAP_COMMAND="sudo -p \"$USER's password:\" $NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME stop\""
    else
-      TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap stop\""
+      TUNTAP_COMMAND="su -mc \"$NETKIT_HOME/bin/manage_tuntap $NETKIT_HOME stop\""
    fi
    if [ -z "$BE_QUIET" ]; then   
       run_command "" \


### PR DESCRIPTION
Current netkit runs umlswitch with '-hub' argument that is making a difference between unicast and broadcast very thin on link layer.

This commit removes '-hub' argument, making umlswitch working as a switch and not a hub. I'm not sure this is very good idea because '-hub' was defintely added on purpose.
