### PR TITLE
Please make Netkit compatible with default Debian/Ubuntu installation (/bin/sh -> dash)

### DIFF
--- a/bin/konsole-tabs.sh
+++ b/bin/konsole-tabs.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2004-2010 Massimo Rimondini - Computer Networks Research Group,
 #     Roma Tre University.

--- a/bin/lclean
+++ b/bin/lclean
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Stefano Pettini, Fabio Ricci, Massimo Rimondini
 #     Computer Networks Research Group, Roma Tre University.

--- a/bin/lcrash
+++ b/bin/lcrash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Stefano Pettini, Fabio Ricci, Massimo Rimondini
 #     Computer Networks Research Group, Roma Tre University.

--- a/bin/lhalt
+++ b/bin/lhalt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Stefano Pettini, Fabio Ricci, Massimo Rimondini
 #     Computer Networks Research Group, Roma Tre University.

--- a/bin/linfo
+++ b/bin/linfo
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Stefano Pettini, Fabio Ricci, Massimo Rimondini
 #     Computer Networks Research Group, Roma Tre University.

--- a/bin/lstart
+++ b/bin/lstart
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Stefano Pettini, Fabio Ricci, Massimo Rimondini
 #     Computer Networks Research Group, Roma Tre University.

--- a/bin/manage_tuntap
+++ b/bin/manage_tuntap
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2004-2009 Massimo Rimondini - Computer Networks Research Group,
 #     Roma Tre University.

--- a/bin/netkit_bash_completion
+++ b/bin/netkit_bash_completion
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2009 Massimo Rimondini - Computer Networks Research Group,
 #     Roma Tre University.

--- a/bin/vclean
+++ b/bin/vclean
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.

--- a/bin/vconfig
+++ b/bin/vconfig
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.

--- a/bin/vcrash
+++ b/bin/vcrash
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.

--- a/bin/vhalt
+++ b/bin/vhalt
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.

--- a/bin/vlist
+++ b/bin/vlist
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.

--- a/bin/vstart
+++ b/bin/vstart
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 #     Copyright 2002-2009 Maurizio Patrignani, Maurizio Pizzonia, Fabio Ricci,
 #     Massimo Rimondini - Computer Networks Research Group, Roma Tre University.


### PR DESCRIPTION
The following commit just replaces '#!/bin/sh' with '#!/bin/bash' instead of fixing all numerous Netkit bashisms.

See also #19.
