### PR TITLE
Start UML machines with mconsole notification sockets attached

### DIFF
--- a/bin/vstart
+++ b/bin/vstart
@@ -718,4 +718,6 @@ if [ "$VM_CON0" = "none" ]; then
    REDIRECT_CONSOLE=">/dev/null 2>&1"
 fi
 
+KERNELCMD="$KERNELCMD mconsole=notify:$MCONSOLE_DIR/notify_$VM_NAME"
+
 run_command "$JUST_PRINT" "$KERNELCMD" "{ $WAKEUP_PORTHELPER $REMOVE_FS_COMMAND $KERNELCMD; cleanHubs $HUBLIST; } $REDIRECT_CONSOLE $BACKGROUND"


### PR DESCRIPTION
UML `mconsole` interface provides a way to set up an event notification channel between vitrual machine and host. This is described here: http://user-mode-linux.sourceforge.net/old/UserModeLinux-HOWTO-10.html#ss10.13 . Event notification can be useful for a variety of purposes.

The code in this commit binds each starting UML machine to its own notification socket on the host.
